### PR TITLE
做了一些性能优化

### DIFF
--- a/chinaiplist.pac
+++ b/chinaiplist.pac
@@ -21,6 +21,10 @@ function belongsToSubnet(host, list) {
   return (masked >>> 0) == (list[x][0] >>> 0);
 }
 
+function isIpAddress(ip) {
+    return /^\d{1,3}(\.\d{1,3}){3}$/.test(ip);
+}
+
 function isChina(host) {
   return belongsToSubnet(host, CHINA);
 }
@@ -29,20 +33,24 @@ function isLan(host) {
   return belongsToSubnet(host, LAN);
 }
 
-var proxy = "SOCKS5 127.0.0.1:1080";
+var proxy = "SOCKS5 192.168.0.2:1080";
 var direct = "DIRECT";
 
 
 function FindProxyForURL(url, host) {
-  if (!isResolvable(host)) {
-      return proxy;
+  if (cache[host] != undefined){
+      return cache[host]? proxy : direct;
   }
-  var remote = dnsResolve(host);
-  if (isChina(remote) || isLan(remote)) {
+  var ip = isIpAddress(host) ? host : dnsResolve(host);
+  if (isLan(ip) || isChina(ip)) {
+      cache[host] = false;
       return direct;
   }
+  cache[host] = true;
   return proxy;
 }
+
+var cache = {};
 
 var CHINA = [
   // Format: [Hex IP, mask]

--- a/chinaiplist.pac
+++ b/chinaiplist.pac
@@ -33,7 +33,7 @@ function isLan(host) {
   return belongsToSubnet(host, LAN);
 }
 
-var proxy = "SOCKS5 192.168.0.2:1080";
+var proxy = "SOCKS5 127.0.0.1:1080";
 var direct = "DIRECT";
 
 


### PR DESCRIPTION
- 去掉isResolvable，因为该方法同样会对域名进行dns解析
- 跳过host本来就是ipv4的dns解析 
- 永久缓存代理结果，避免下次重新扫描白名单